### PR TITLE
Fix Dependabot security finding in Spring example

### DIFF
--- a/helloworlds/1.1-common-frameworks-and-lib/spring/pom.xml
+++ b/helloworlds/1.1-common-frameworks-and-lib/spring/pom.xml
@@ -27,13 +27,13 @@
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-context</artifactId>
-                <version>4.2.2.RELEASE</version>
+                <version>5.3.6</version>
             </dependency>
 
             <dependency>
                 <groupId>org.springframework.security</groupId>
                 <artifactId>spring-security-web</artifactId>
-                <version>4.0.3.RELEASE</version>
+                <version>5.4.6</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
GitHub's Dependabot found a security issue in [helloworlds/1.1-common-frameworks-and-lib/spring/](https://github.com/Vedenin/useful-java-links/tree/master/helloworlds/1.1-common-frameworks-and-lib/spring) regarding the dependency `spring-security-web`. But the proposed solution has two issues:

1. It only bumps `spring-security-web` but not `spring-context` which is also necessary.
2. It does not bump to the current version but to the last version with the "old" versioning schema of Spring. They got rid of the `.RELEASE` part in their versions.