### PR TITLE
fix(sec): upgrade org.apache.opennlp:opennlp-tools to 1.8.2

### DIFF
--- a/helloworlds/2.8-natural-language-processing/opennlp/pom.xml
+++ b/helloworlds/2.8-natural-language-processing/opennlp/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <groupId>com.github.vedenin</groupId>
     <version>0.01</version>
@@ -28,7 +26,7 @@
         <dependency>
             <groupId>org.apache.opennlp</groupId>
             <artifactId>opennlp-tools</artifactId>
-            <version>1.6.0</version>
+            <version>1.8.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.opennlp</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.opennlp:opennlp-tools 1.6.0
- [CVE-2017-12620](https://www.oscs1024.com/hd/CVE-2017-12620)


### What did I do？
Upgrade org.apache.opennlp:opennlp-tools from 1.6.0 to 1.8.2 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS