### PR TITLE
fix(sec): upgrade org.springframework:spring-context to 5.3.19

### DIFF
--- a/helloworlds/1.1-common-frameworks-and-lib/spring/pom.xml
+++ b/helloworlds/1.1-common-frameworks-and-lib/spring/pom.xml
@@ -27,7 +27,7 @@
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-context</artifactId>
-                <version>5.3.6</version>
+                <version>5.3.19</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.springframework:spring-context 5.3.6
- [CVE-2022-22968](https://www.oscs1024.com/hd/CVE-2022-22968)


### What did I do？
Upgrade org.springframework:spring-context from 5.3.6 to 5.3.19 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS