### PR TITLE
fix(sec): upgrade org.springframework.security:spring-security-web to 5.5.7

### DIFF
--- a/helloworlds/1.1-common-frameworks-and-lib/spring/pom.xml
+++ b/helloworlds/1.1-common-frameworks-and-lib/spring/pom.xml
@@ -33,7 +33,7 @@
             <dependency>
                 <groupId>org.springframework.security</groupId>
                 <artifactId>spring-security-web</artifactId>
-                <version>5.4.6</version>
+                <version>5.5.7</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.springframework.security:spring-security-web 5.4.6
- [CVE-2022-22978](https://www.oscs1024.com/hd/CVE-2022-22978)


### What did I do？
Upgrade org.springframework.security:spring-security-web from 5.4.6 to 5.5.7 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS