### PR TITLE
fix(sec): upgrade edu.stanford.nlp:stanford-corenlp to 

### DIFF
--- a/helloworlds/2.8-natural-language-processing/stanford-core-nlp/pom.xml
+++ b/helloworlds/2.8-natural-language-processing/stanford-core-nlp/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>edu.stanford.nlp</groupId>
             <artifactId>stanford-corenlp</artifactId>
-            <version>3.6.0</version>
+            <version>4.4.0</version>
             <classifier>models</classifier>
         </dependency>
     </dependencies>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in edu.stanford.nlp:stanford-corenlp 3.6.0
- [CVE-2021-3869](https://www.oscs1024.com/hd/CVE-2021-3869)


### What did I do？
Upgrade edu.stanford.nlp:stanford-corenlp from 3.6.0 to  for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS